### PR TITLE
HomeView: unblock first map paint and restore marker rendering on initial load

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,11 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@vue-leaflet/vue-leaflet": "^0.10.1",
-        "axios": "^1.16.0",
-        "baseline-browser-mapping": "^2.10.29",
+        "axios": "^1.16.1",
+        "baseline-browser-mapping": "^2.10.31",
         "bootstrap": "^5.3.8",
         "bootstrap-vue-next": "^0.45.3",
-        "caniuse-lite": "^1.0.30001792",
+        "caniuse-lite": "^1.0.30001793",
         "flag-icons": "^7.5.0",
         "fuse.js": "^7.3.0",
         "leaflet": "^1.9.4",
@@ -33,13 +33,13 @@
         "@rushstack/eslint-patch": "^1.16.1",
         "@types/leaflet": "^1.9.21",
         "@types/markdown-it": "^14.1.2",
-        "@types/node": "^25.8.0",
+        "@types/node": "^25.9.0",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vue/compiler-sfc": "^3.5.34",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.7.0",
         "@vue/tsconfig": "^0.9.1",
-        "eslint": "^10.3.0",
+        "eslint": "^10.4.0",
         "eslint-plugin-vue": "^10.9.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.8.3",
@@ -52,7 +52,7 @@
         "vite-plugin-pwa": "^1.3.0",
         "vite-plugin-vue-devtools": "^8.1.2",
         "vite-svg-loader": "^5.1.1",
-        "vue-tsc": "^3.2.8",
+        "vue-tsc": "^3.3.1",
       },
     },
   },
@@ -309,7 +309,7 @@
 
     "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.5", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
 
     "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
 
@@ -523,7 +523,7 @@
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
-    "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/gensync": ["@types/gensync@1.0.4", "", {}, "sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA=="],
 
@@ -539,7 +539,7 @@
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
-    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
@@ -607,7 +607,7 @@
 
     "@vue/eslint-config-typescript": ["@vue/eslint-config-typescript@14.7.0", "", { "dependencies": { "@typescript-eslint/utils": "^8.56.0", "fast-glob": "^3.3.3", "typescript-eslint": "^8.56.0", "vue-eslint-parser": "^10.4.0" }, "peerDependencies": { "eslint": "^9.10.0 || ^10.0.0", "eslint-plugin-vue": "^9.28.0 || ^10.0.0", "typescript": ">=4.8.4" }, "optionalPeers": ["typescript"] }, "sha512-iegbMINVc+seZ/QxtzWiOBozctrHiF2WvGedruu2EbLujg9VuU0FQiNcN2z1ycuaoKKpF4m2qzB5HDEMKbxtIg=="],
 
-    "@vue/language-core": ["@vue/language-core@3.2.8", "", { "dependencies": { "@volar/language-core": "2.4.28", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.1.2", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.4" } }, "sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g=="],
+    "@vue/language-core": ["@vue/language-core@3.3.1", "", { "dependencies": { "@volar/language-core": "2.4.28", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.2.0", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.4" } }, "sha512-NP8g6V7x81NVOXbLupUvYY6i6LqUkjkVowe2epRedmpgaFCOdjgWHE/rQBvEJ4r7koAYODIjGeBWEdt6n7jYXQ=="],
 
     "@vue/reactivity": ["@vue/reactivity@3.5.34", "", { "dependencies": { "@vue/shared": "3.5.34" } }, "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ=="],
 
@@ -639,7 +639,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "alien-signals": ["alien-signals@3.1.2", "", {}, "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw=="],
+    "alien-signals": ["alien-signals@3.2.1", "", {}, "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -679,7 +679,7 @@
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
-    "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
+    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
@@ -705,7 +705,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.31", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q=="],
 
     "basic-ftp": ["basic-ftp@5.2.0", "", {}, "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="],
 
@@ -749,7 +749,7 @@
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -935,7 +935,7 @@
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
-    "eslint": ["eslint@10.3.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.5.5", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw=="],
+    "eslint": ["eslint@10.4.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.0.1", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": "build/bin/cli.js" }, "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw=="],
 
@@ -1107,7 +1107,7 @@
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1875,7 +1875,7 @@
 
     "vue-router": ["vue-router@5.0.6", "", { "dependencies": { "@babel/generator": "^7.28.6", "@vue-macros/common": "^3.1.1", "@vue/devtools-api": "^8.0.6", "ast-walker-scope": "^0.8.3", "chokidar": "^5.0.0", "json5": "^2.2.3", "local-pkg": "^1.1.2", "magic-string": "^0.30.21", "mlly": "^1.8.0", "muggle-string": "^0.4.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "scule": "^1.3.0", "tinyglobby": "^0.2.15", "unplugin": "^3.0.0", "unplugin-utils": "^0.3.1", "yaml": "^2.8.2" }, "peerDependencies": { "@pinia/colada": ">=0.21.2", "@vue/compiler-sfc": "^3.5.17", "pinia": "^3.0.4", "vue": "^3.5.0" }, "optionalPeers": ["@pinia/colada", "@vue/compiler-sfc", "pinia"] }, "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w=="],
 
-    "vue-tsc": ["vue-tsc@3.2.8", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.2.8" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-27vTLJ6Q2370obOd0PFYoYoKnmXJ521uUIedrs3Zhhhg/8YG10VOCMmwt+JQslatpAMTDbnWiitLnoD5VlIvog=="],
+    "vue-tsc": ["vue-tsc@3.3.1", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.3.1" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-webBP3jhlxzhELZ2g+11KJ6pg5OVY1xWhWrj7N/yQMi1CrtxJnW+tUACyRVeDK0cQNLP2Va5HNYK8pe+7c+msw=="],
 
     "vue3-markdown-it": ["vue3-markdown-it@1.0.10", "", { "dependencies": { "markdown-it": "^12.3.2", "markdown-it-abbr": "^1.0.4", "markdown-it-anchor": "^8.4.1", "markdown-it-deflist": "^2.1.0", "markdown-it-emoji": "^2.0.0", "markdown-it-footnote": "^3.0.3", "markdown-it-highlightjs": "^3.6.0", "markdown-it-ins": "^3.0.1", "markdown-it-mark": "^3.0.1", "markdown-it-sub": "^1.0.0", "markdown-it-sup": "^1.0.0", "markdown-it-task-lists": "^2.1.1", "markdown-it-toc-done-right": "^4.2.0" } }, "sha512-mTvHu0zl7jrh7ojgaZ+tTpCLiS4CVg4bTgTu4KGhw/cRRY5YgIG8QgFAPu6kCzSW6Znc9a52Beb6hFvF4hSMkQ=="],
 
@@ -2065,6 +2065,8 @@
 
     "@puppeteer/browsers/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "@rollup/pluginutils/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
     "@sentry/hub/@sentry/types": ["@sentry/types@6.19.7", "", {}, "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="],
@@ -2145,8 +2147,6 @@
 
     "eslint-plugin-vue/@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
 
-    "eslint-scope/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
-
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -2164,6 +2164,8 @@
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "inquirer/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -2215,6 +2217,8 @@
 
     "npm-run-all/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "pac-proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "param-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "pascal-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -2222,6 +2226,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "proxy-agent/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -2625,15 +2631,11 @@
 
     "@netlify/plugin-lighthouse/lighthouse/@sentry/node/cookie": ["cookie@0.4.2", "", {}, "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="],
 
-    "@netlify/plugin-lighthouse/lighthouse/@sentry/node/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
     "@netlify/plugin-lighthouse/lighthouse/lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
     "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/devtools-protocol": ["devtools-protocol@0.0.981744", "", {}, "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg=="],
-
-    "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -2745,15 +2747,9 @@
 
     "@iconify/utils/mlly/pkg-types/mlly/ufo": ["ufo@1.5.4", "", {}, "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="],
 
-    "@netlify/plugin-lighthouse/lighthouse/@sentry/node/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
-
     "@netlify/plugin-lighthouse/lighthouse/lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
-
-    "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
-
-    "@netlify/plugin-lighthouse/lighthouse/puppeteer-core/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@netlify/plugin-lighthouse/lighthouse/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/src/components/map/LocationMap.vue
+++ b/src/components/map/LocationMap.vue
@@ -34,6 +34,14 @@
         ></l-tile-layer>
 
         <l-tile-layer
+          v-if="effectiveBaseLayer === 'carto'"
+          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+          layer-type="base"
+          name="Map Minimal"
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        ></l-tile-layer>
+
+        <l-tile-layer
           v-if="effectiveBaseLayer === 'osm'"
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           layer-type="base"
@@ -41,122 +49,118 @@
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         ></l-tile-layer>
 
-        <!-- Use Suspense for markers only, not the entire map -->
-        <Suspense>
-          <l-layer-group
-            v-if="pinsReady && projectsFinished && projectsFinished.length > 0"
-            layer-type="overlay"
-            :name="layerLabelProjectsFinished"
+        <!-- Markers layer, loaded when pins ready -->
+        <l-layer-group
+          v-if="pinsReady && projectsFinished && projectsFinished.length > 0"
+          layer-type="overlay"
+          :name="layerLabelProjectsFinished"
+        >
+          <!-- Verwende v-memo für bessere Performance bei der Marker-Darstellung -->
+          <l-marker
+            v-for="loc in projectsFinished"
+            v-memo="[
+              loc.id,
+              loc.latitude,
+              loc.longitude,
+              selectedLocation?.id === loc.id,
+              currentZoom > 7,
+            ]"
+            :id="loc.id"
+            :key="loc.id"
+            :lat-lng="[loc.latitude, loc.longitude]"
+            :title="loc.name"
+            @click="onMarkerClick(loc)"
           >
-            <!-- Verwende v-memo für bessere Performance bei der Marker-Darstellung -->
-            <l-marker
-              v-for="loc in projectsFinished"
-              v-memo="[
-                loc.id,
-                loc.latitude,
-                loc.longitude,
-                selectedLocation?.id === loc.id,
-                currentZoom > 7,
-              ]"
-              :id="loc.id"
-              :key="loc.id"
-              :lat-lng="[loc.latitude, loc.longitude]"
-              :title="loc.name"
-              @click="onMarkerClick(loc)"
-            >
-              <l-icon
-                :icon-url="getPin(loc)"
-                :class-name="pinClass(loc)"
-                :icon-size="[28, 39]"
-                :icon-anchor="[14, 39]"
-              ></l-icon>
-              <!-- Tooltips nur bei Bedarf rendern, um DOM-Größe zu reduzieren -->
-              <l-tooltip v-if="currentZoom > 7">
-                <span>{{ loc.name }}</span>
-                <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
-              </l-tooltip>
-            </l-marker>
-          </l-layer-group>
+            <l-icon
+              :icon-url="getPin(loc)"
+              :class-name="pinClass(loc)"
+              :icon-size="[28, 39]"
+              :icon-anchor="[14, 39]"
+            ></l-icon>
+            <!-- Tooltips nur bei Bedarf rendern, um DOM-Größe zu reduzieren -->
+            <l-tooltip v-if="currentZoom > 7">
+              <span>{{ loc.name }}</span>
+              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+            </l-tooltip>
+          </l-marker>
+        </l-layer-group>
 
-          <l-layer-group
-            v-if="
-              pinsReady &&
-              projectsUnderConstruction &&
-              projectsUnderConstruction.length > 0
-            "
-            layer-type="overlay"
-            :name="layerLabelProjectsUnderConstruction"
+        <l-layer-group
+          v-if="
+            pinsReady &&
+            projectsUnderConstruction &&
+            projectsUnderConstruction.length > 0
+          "
+          layer-type="overlay"
+          :name="layerLabelProjectsUnderConstruction"
+        >
+          <l-marker
+            v-for="loc in projectsUnderConstruction"
+            v-memo="[
+              loc.id,
+              loc.latitude,
+              loc.longitude,
+              selectedLocation?.id === loc.id,
+              currentZoom > 7,
+            ]"
+            :id="loc.id"
+            :key="loc.id"
+            :lat-lng="[loc.latitude, loc.longitude]"
+            :title="loc.name"
+            @click="onMarkerClick(loc)"
           >
-            <l-marker
-              v-for="loc in projectsUnderConstruction"
-              v-memo="[
-                loc.id,
-                loc.latitude,
-                loc.longitude,
-                selectedLocation?.id === loc.id,
-                currentZoom > 7,
-              ]"
-              :id="loc.id"
-              :key="loc.id"
-              :lat-lng="[loc.latitude, loc.longitude]"
-              :title="loc.name"
-              @click="onMarkerClick(loc)"
-            >
-              <l-icon
-                :icon-url="getPin(loc)"
-                :class-name="pinClass(loc)"
-                :icon-size="[28, 39]"
-                :icon-anchor="[14, 39]"
-              ></l-icon>
-              <l-tooltip v-if="currentZoom > 7">
-                <span>{{ loc.name }}</span>
-                <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
-              </l-tooltip>
-            </l-marker>
-          </l-layer-group>
+            <l-icon
+              :icon-url="getPin(loc)"
+              :class-name="pinClass(loc)"
+              :icon-size="[28, 39]"
+              :icon-anchor="[14, 39]"
+            ></l-icon>
+            <l-tooltip v-if="currentZoom > 7">
+              <span>{{ loc.name }}</span>
+              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+            </l-tooltip>
+          </l-marker>
+        </l-layer-group>
 
-          <l-layer-group
-            v-if="pinsReady && projectsPlanned && projectsPlanned.length > 0"
-            layer-type="overlay"
-            :name="layerLabelProjectsPlanned"
+        <l-layer-group
+          v-if="pinsReady && projectsPlanned && projectsPlanned.length > 0"
+          layer-type="overlay"
+          :name="layerLabelProjectsPlanned"
+        >
+          <l-marker
+            v-for="loc in projectsPlanned"
+            v-memo="[
+              loc.id,
+              loc.latitude,
+              loc.longitude,
+              selectedLocation?.id === loc.id,
+              currentZoom > 7,
+            ]"
+            :id="loc.id"
+            :key="loc.id"
+            :lat-lng="[loc.latitude, loc.longitude]"
+            :title="loc.name"
+            @click="onMarkerClick(loc)"
           >
-            <l-marker
-              v-for="loc in projectsPlanned"
-              v-memo="[
-                loc.id,
-                loc.latitude,
-                loc.longitude,
-                selectedLocation?.id === loc.id,
-                currentZoom > 7,
-              ]"
-              :id="loc.id"
-              :key="loc.id"
-              :lat-lng="[loc.latitude, loc.longitude]"
-              :title="loc.name"
-              @click="onMarkerClick(loc)"
-            >
-              <l-icon
-                :icon-url="getPin(loc)"
-                :class-name="pinClass(loc)"
-                :icon-size="[28, 39]"
-                :icon-anchor="[14, 39]"
-              ></l-icon>
-              <l-tooltip v-if="currentZoom > 7">
-                <span>{{ loc.name }}</span>
-                <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
-              </l-tooltip>
-            </l-marker>
-          </l-layer-group>
-
-          <template #fallback>
-            <div class="pins-loading-indicator">
-              <div class="spinner-border text-primary" role="status">
-                <span class="visually-hidden">Loading pins...</span>
-              </div>
-              <p>Loading project data...</p>
-            </div>
-          </template>
-        </Suspense>
+            <l-icon
+              :icon-url="getPin(loc)"
+              :class-name="pinClass(loc)"
+              :icon-size="[28, 39]"
+              :icon-anchor="[14, 39]"
+            ></l-icon>
+            <l-tooltip v-if="currentZoom > 7">
+              <span>{{ loc.name }}</span>
+              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+            </l-tooltip>
+          </l-marker>
+        </l-layer-group>
+        
+        <!-- Fallback loading indicator when map is ready but pins aren't yet -->
+        <div v-if="mapReady && !pinsReady" class="pins-loading-indicator" style="position: absolute; z-index: 1000; top: 50%; left: 50%; transform: translate(-50%, -50%); background: rgba(255,255,255,0.8); padding: 10px; border-radius: 5px;">
+          <div class="spinner-border text-primary" role="status" style="width: 1.5rem; height: 1.5rem;">
+            <span class="visually-hidden">Loading pins...</span>
+          </div>
+        </div>
       </l-map>
     </b-overlay>
     <project-details
@@ -216,8 +220,8 @@ const props = defineProps({
     default: () => [],
   },
   baseLayer: {
-    type: String as () => 'satellite' | 'osm',
-    default: 'osm',
+    type: String as () => 'satellite' | 'osm' | 'carto',
+    default: 'carto',
   },
 });
 
@@ -260,14 +264,12 @@ const mapInitialized = ref(false);
 const initialDataLoaded = ref(false);
 const pinsReady = ref(false); // New status for pins
 const selectedLocation = shallowRef<Project | undefined>(undefined);
-const effectiveBaseLayer = ref<'satellite' | 'osm'>('osm');
+const effectiveBaseLayer = ref<'satellite' | 'osm' | 'carto'>('carto');
 // Delay values tuned to prioritize first map paint while still showing pins/layer quickly after.
 const PINS_IDLE_TIMEOUT = 250;
-const LAYER_IDLE_TIMEOUT = 400;
 // Fallback delays for browsers without requestIdleCallback.
 // Keep these short so pins/layer appear quickly after initial paint.
 const PINS_FALLBACK_DELAY = 80;
-const LAYER_FALLBACK_DELAY = 150;
 
 const windowWithIdleCallback = window as Window & {
   requestIdleCallback?: (
@@ -278,9 +280,7 @@ const windowWithIdleCallback = window as Window & {
 };
 
 let pinsRenderTimeout: number | null = null;
-let satelliteSwitchTimeout: number | null = null;
 let pinsIdleHandle: number | null = null;
-let layerIdleHandle: number | null = null;
 
 const clearPinsSchedule = () => {
   if (pinsRenderTimeout) {
@@ -290,17 +290,6 @@ const clearPinsSchedule = () => {
   if (pinsIdleHandle && windowWithIdleCallback.cancelIdleCallback) {
     windowWithIdleCallback.cancelIdleCallback(pinsIdleHandle);
     pinsIdleHandle = null;
-  }
-};
-
-const clearLayerSchedule = () => {
-  if (satelliteSwitchTimeout) {
-    clearTimeout(satelliteSwitchTimeout);
-    satelliteSwitchTimeout = null;
-  }
-  if (layerIdleHandle && windowWithIdleCallback.cancelIdleCallback) {
-    windowWithIdleCallback.cancelIdleCallback(layerIdleHandle);
-    layerIdleHandle = null;
   }
 };
 
@@ -334,35 +323,8 @@ const schedulePinsRendering = () => {
   }, PINS_FALLBACK_DELAY);
 };
 
-const scheduleBaseLayerUpdate = (layer: 'satellite' | 'osm') => {
-  clearLayerSchedule();
-
-  if (layer === 'osm') {
-    effectiveBaseLayer.value = 'osm';
-    return;
-  }
-
-  // Satellite layer is intentionally delayed so initial map paint stays fast.
-  effectiveBaseLayer.value = 'osm';
-  if (!mapInitialized.value) {
-    return;
-  }
-
-  if (windowWithIdleCallback.requestIdleCallback) {
-    const idleHandle = windowWithIdleCallback.requestIdleCallback(() => {
-      effectiveBaseLayer.value = 'satellite';
-      if (layerIdleHandle === idleHandle) {
-        layerIdleHandle = null;
-      }
-    }, { timeout: LAYER_IDLE_TIMEOUT });
-    layerIdleHandle = idleHandle;
-    return;
-  }
-
-  satelliteSwitchTimeout = window.setTimeout(() => {
-    effectiveBaseLayer.value = 'satellite';
-    satelliteSwitchTimeout = null;
-  }, LAYER_FALLBACK_DELAY);
+const scheduleBaseLayerUpdate = (layer: 'satellite' | 'osm' | 'carto') => {
+  effectiveBaseLayer.value = layer;
 };
 const mapOptions = ref({
   zoomSnap: 0.5,
@@ -573,7 +535,6 @@ watch(
 // Bereinige Timeouts beim Unmount
 onBeforeUnmount(() => {
   clearPinsSchedule();
-  clearLayerSchedule();
 
   if (zoomTimeout) {
     clearTimeout(zoomTimeout);

--- a/src/components/map/LocationMap.vue
+++ b/src/components/map/LocationMap.vue
@@ -41,118 +41,122 @@
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         ></l-tile-layer>
 
-        <l-layer-group
-          v-if="pinsReady && projectsFinished && projectsFinished.length > 0"
-          layer-type="overlay"
-          :name="layerLabelProjectsFinished"
-        >
-          <!-- Verwende v-memo für bessere Performance bei der Marker-Darstellung -->
-          <l-marker
-            v-for="loc in projectsFinished"
-            v-memo="[
-              loc.id,
-              loc.latitude,
-              loc.longitude,
-              selectedLocation?.id === loc.id,
-              currentZoom > 7,
-            ]"
-            :id="loc.id"
-            :key="loc.id"
-            :lat-lng="[loc.latitude, loc.longitude]"
-            :title="loc.name"
-            @click="onMarkerClick(loc)"
+        <!-- Use Suspense for markers only, not the entire map -->
+        <Suspense>
+          <l-layer-group
+            v-if="pinsReady && projectsFinished && projectsFinished.length > 0"
+            layer-type="overlay"
+            :name="layerLabelProjectsFinished"
           >
-            <l-icon
-              :icon-url="getPin(loc)"
-              :class-name="pinClass(loc)"
-              :icon-size="[28, 39]"
-              :icon-anchor="[14, 39]"
-            ></l-icon>
-            <!-- Tooltips nur bei Bedarf rendern, um DOM-Größe zu reduzieren -->
-            <l-tooltip v-if="currentZoom > 7">
-              <span>{{ loc.name }}</span>
-              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
-            </l-tooltip>
-          </l-marker>
-        </l-layer-group>
+            <!-- Verwende v-memo für bessere Performance bei der Marker-Darstellung -->
+            <l-marker
+              v-for="loc in projectsFinished"
+              v-memo="[
+                loc.id,
+                loc.latitude,
+                loc.longitude,
+                selectedLocation?.id === loc.id,
+                currentZoom > 7,
+              ]"
+              :id="loc.id"
+              :key="loc.id"
+              :lat-lng="[loc.latitude, loc.longitude]"
+              :title="loc.name"
+              @click="onMarkerClick(loc)"
+            >
+              <l-icon
+                :icon-url="getPin(loc)"
+                :class-name="pinClass(loc)"
+                :icon-size="[28, 39]"
+                :icon-anchor="[14, 39]"
+              ></l-icon>
+              <!-- Tooltips nur bei Bedarf rendern, um DOM-Größe zu reduzieren -->
+              <l-tooltip v-if="currentZoom > 7">
+                <span>{{ loc.name }}</span>
+                <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+              </l-tooltip>
+            </l-marker>
+          </l-layer-group>
 
-        <l-layer-group
-          v-if="
-            pinsReady &&
-            projectsUnderConstruction &&
-            projectsUnderConstruction.length > 0
-          "
-          layer-type="overlay"
-          :name="layerLabelProjectsUnderConstruction"
-        >
-          <l-marker
-            v-for="loc in projectsUnderConstruction"
-            v-memo="[
-              loc.id,
-              loc.latitude,
-              loc.longitude,
-              selectedLocation?.id === loc.id,
-              currentZoom > 7,
-            ]"
-            :id="loc.id"
-            :key="loc.id"
-            :lat-lng="[loc.latitude, loc.longitude]"
-            :title="loc.name"
-            @click="onMarkerClick(loc)"
+          <l-layer-group
+            v-if="
+              pinsReady &&
+              projectsUnderConstruction &&
+              projectsUnderConstruction.length > 0
+            "
+            layer-type="overlay"
+            :name="layerLabelProjectsUnderConstruction"
           >
-            <l-icon
-              :icon-url="getPin(loc)"
-              :class-name="pinClass(loc)"
-              :icon-size="[28, 39]"
-              :icon-anchor="[14, 39]"
-            ></l-icon>
-            <l-tooltip v-if="currentZoom > 7">
-              <span>{{ loc.name }}</span>
-              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
-            </l-tooltip>
-          </l-marker>
-        </l-layer-group>
+            <l-marker
+              v-for="loc in projectsUnderConstruction"
+              v-memo="[
+                loc.id,
+                loc.latitude,
+                loc.longitude,
+                selectedLocation?.id === loc.id,
+                currentZoom > 7,
+              ]"
+              :id="loc.id"
+              :key="loc.id"
+              :lat-lng="[loc.latitude, loc.longitude]"
+              :title="loc.name"
+              @click="onMarkerClick(loc)"
+            >
+              <l-icon
+                :icon-url="getPin(loc)"
+                :class-name="pinClass(loc)"
+                :icon-size="[28, 39]"
+                :icon-anchor="[14, 39]"
+              ></l-icon>
+              <l-tooltip v-if="currentZoom > 7">
+                <span>{{ loc.name }}</span>
+                <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+              </l-tooltip>
+            </l-marker>
+          </l-layer-group>
 
-        <l-layer-group
-          v-if="pinsReady && projectsPlanned && projectsPlanned.length > 0"
-          layer-type="overlay"
-          :name="layerLabelProjectsPlanned"
-        >
-          <l-marker
-            v-for="loc in projectsPlanned"
-            v-memo="[
-              loc.id,
-              loc.latitude,
-              loc.longitude,
-              selectedLocation?.id === loc.id,
-              currentZoom > 7,
-            ]"
-            :id="loc.id"
-            :key="loc.id"
-            :lat-lng="[loc.latitude, loc.longitude]"
-            :title="loc.name"
-            @click="onMarkerClick(loc)"
+          <l-layer-group
+            v-if="pinsReady && projectsPlanned && projectsPlanned.length > 0"
+            layer-type="overlay"
+            :name="layerLabelProjectsPlanned"
           >
-            <l-icon
-              :icon-url="getPin(loc)"
-              :class-name="pinClass(loc)"
-              :icon-size="[28, 39]"
-              :icon-anchor="[14, 39]"
-            ></l-icon>
-            <l-tooltip v-if="currentZoom > 7">
-              <span>{{ loc.name }}</span>
-              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
-            </l-tooltip>
-          </l-marker>
-        </l-layer-group>
+            <l-marker
+              v-for="loc in projectsPlanned"
+              v-memo="[
+                loc.id,
+                loc.latitude,
+                loc.longitude,
+                selectedLocation?.id === loc.id,
+                currentZoom > 7,
+              ]"
+              :id="loc.id"
+              :key="loc.id"
+              :lat-lng="[loc.latitude, loc.longitude]"
+              :title="loc.name"
+              @click="onMarkerClick(loc)"
+            >
+              <l-icon
+                :icon-url="getPin(loc)"
+                :class-name="pinClass(loc)"
+                :icon-size="[28, 39]"
+                :icon-anchor="[14, 39]"
+              ></l-icon>
+              <l-tooltip v-if="currentZoom > 7">
+                <span>{{ loc.name }}</span>
+                <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+              </l-tooltip>
+            </l-marker>
+          </l-layer-group>
 
-        <!-- Lade-Indikator für Pins -->
-        <div v-if="mapInitialized && !pinsReady" class="pins-loading-indicator">
-          <div class="spinner-border text-primary" role="status">
-            <span class="visually-hidden">Loading pins...</span>
-          </div>
-          <p>Loading project data...</p>
-        </div>
+          <template #fallback>
+            <div class="pins-loading-indicator">
+              <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading pins...</span>
+              </div>
+              <p>Loading project data...</p>
+            </div>
+          </template>
+        </Suspense>
       </l-map>
     </b-overlay>
     <project-details
@@ -178,7 +182,7 @@ import { storeToRefs } from "pinia";
 import { useLoadingStore } from "../../stores/loading.store";
 import { useCategoryStore } from "../../stores/category.store";
 import { useProjectStore } from "@/features/projects/stores/project.store";
-import { useFilterStore } from "@/stores/filter.store";
+import { useFilterStore } from "../../stores/filter.store";
 import L, { latLngBounds } from "leaflet";
 import {
   LMap,

--- a/src/components/map/LocationMap.vue
+++ b/src/components/map/LocationMap.vue
@@ -529,6 +529,8 @@ const onSidePanelClose = () => {
 // für bessere Performance und Speichernutzung
 const PIN_CACHE = new Map<string, string>();
 const DEFAULT_PIN = "/pins/default.png";
+// Keep this list in sync with /public/pins/*.png so missing combinations
+// can gracefully fall back to an existing icon instead of invisible markers.
 const AVAILABLE_PINS = new Set([
   "default",
   "school",
@@ -537,6 +539,7 @@ const AVAILABLE_PINS = new Set([
   "teacher",
   "school-well",
   "well-school",
+  // Legacy fallback asset name used by existing deployments.
   "undefined",
 ]);
 const MARKER_CLASS_CACHE = new Map<string, string>();

--- a/src/components/map/LocationMap.vue
+++ b/src/components/map/LocationMap.vue
@@ -308,7 +308,7 @@ const schedulePinsRendering = () => {
   clearPinsSchedule();
   pinsReady.value = false;
 
-  if (!mapInitialized.value || !map.value?.leafletObject) {
+  if (!mapInitialized.value) {
     return;
   }
 

--- a/src/components/map/LocationMap.vue
+++ b/src/components/map/LocationMap.vue
@@ -529,6 +529,16 @@ const onSidePanelClose = () => {
 // für bessere Performance und Speichernutzung
 const PIN_CACHE = new Map<string, string>();
 const DEFAULT_PIN = "/pins/default.png";
+const AVAILABLE_PINS = new Set([
+  "default",
+  "school",
+  "midwife",
+  "well",
+  "teacher",
+  "school-well",
+  "well-school",
+  "undefined",
+]);
 const MARKER_CLASS_CACHE = new Map<string, string>();
 
 // Computed-Wert für den aktuellen Zoom-Level
@@ -615,9 +625,21 @@ const getPin = (location: Project) => {
       return DEFAULT_PIN;
     }
 
-    const pinUrl = `/pins/${categoryNames}.png`;
-    PIN_CACHE.set(cacheKey, pinUrl);
-    return pinUrl;
+    if (AVAILABLE_PINS.has(categoryNames)) {
+      const pinUrl = `/pins/${categoryNames}.png`;
+      PIN_CACHE.set(cacheKey, pinUrl);
+      return pinUrl;
+    }
+
+    const primaryCategory = categoryNames.split("-")[0];
+    if (primaryCategory && AVAILABLE_PINS.has(primaryCategory)) {
+      const pinUrl = `/pins/${primaryCategory}.png`;
+      PIN_CACHE.set(cacheKey, pinUrl);
+      return pinUrl;
+    }
+
+    PIN_CACHE.set(cacheKey, DEFAULT_PIN);
+    return DEFAULT_PIN;
   } catch (error) {
     console.error("Error getting pin for location:", error);
     PIN_CACHE.set(cacheKey, DEFAULT_PIN);

--- a/src/features/projects/repositories/project.repository.ts
+++ b/src/features/projects/repositories/project.repository.ts
@@ -7,7 +7,27 @@ const base = new NocoDBService(tableId);
 // Raw shape coming from NocoDB v2
 export interface RawProjectRecord {
   id: number;
-  fields: {
+  Id?: number;
+  Name?: string;
+  Title?: string;
+  Latitude?: number;
+  Longitude?: number;
+  State?: string;
+  Status?: string;
+  Category?: unknown;
+  Country?: unknown;
+  TeaserImage?: unknown;
+  Notes?: string;
+  Link?: string;
+  Since?: string;
+  Gallery?: unknown;
+  "Name (de)"?: string;
+  "Name (en)"?: string;
+  "Name (fr)"?: string;
+  "Notes (de)"?: string;
+  "Notes (en)"?: string;
+  "Notes (fr)"?: string;
+  fields?: {
     Name?: string;
     Title?: string;
     Latitude?: number;

--- a/src/features/projects/repositories/project.repository.ts
+++ b/src/features/projects/repositories/project.repository.ts
@@ -7,6 +7,7 @@ const base = new NocoDBService(tableId);
 // Raw shape coming from NocoDB v2
 export interface RawProjectRecord {
   id: number;
+  // NocoDB can return the primary key as "Id" in flat record payloads.
   Id?: number;
   Name?: string;
   Title?: string;

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -11,6 +11,15 @@ interface CacheData {
   mapData?: Array<Project>;
 }
 
+function resolveRecordFields(
+  record: RawProjectRecord,
+): Record<string, unknown> {
+  if (record.fields && typeof record.fields === "object") {
+    return record.fields as Record<string, unknown>;
+  }
+  return record as unknown as Record<string, unknown>;
+}
+
 // Cache-Gültigkeit (5 Minuten)
 const CACHE_VALIDITY_MS = 5 * 60 * 1000;
 
@@ -63,13 +72,8 @@ function processProjectData(
 
   // Verwende eine for-Schleife statt map/filter für bessere Performance
   for (let i = 0; i < len; i++) {
-    const record = list[i] as RawProjectRecord & {
-      Id?: number;
-      [key: string]: unknown;
-    };
-    const sourceFields =
-      (record.fields as Record<string, unknown> | undefined) ||
-      (record as unknown as Record<string, unknown>);
+    const record = list[i];
+    const sourceFields = resolveRecordFields(record);
 
     // Grundlegende Validierung - wir brauchen mindestens eine ID und Koordinaten
     const id = record.id ?? record.Id;
@@ -101,7 +105,7 @@ function processProjectData(
       name: ((sourceFields as any)?.[nameField] || sourceFields?.Name || "Unbenannt") as string,
       latitude: latNum,
       longitude: lngNum,
-      state: ((sourceFields?.State as string) || (sourceFields?.Status as string) || "finished") as string,
+      state: (sourceFields?.State || sourceFields?.Status || "finished") as string,
       category: undefined,
       country: undefined,
       notes: undefined,

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -25,6 +25,18 @@ function resolveProjectState(sourceFields: Record<string, unknown>): string {
   return (sourceFields.State || sourceFields.Status || "finished") as string;
 }
 
+function resolveProjectId(
+  record: RawProjectRecord,
+  sourceFields: Record<string, unknown>,
+): number | undefined {
+  if (typeof record.id === "number" && !Number.isNaN(record.id)) {
+    return record.id;
+  }
+  const altId = sourceFields.Id;
+  const altNum = Number(altId);
+  return Number.isFinite(altNum) ? altNum : undefined;
+}
+
 // Cache-Gültigkeit (5 Minuten)
 const CACHE_VALIDITY_MS = 5 * 60 * 1000;
 
@@ -81,9 +93,9 @@ function processProjectData(
     const sourceFields = resolveRecordFields(record);
 
     // Grundlegende Validierung - wir brauchen mindestens eine ID und Koordinaten
-    const id = record.id ?? Number(sourceFields.Id);
-    const lat = sourceFields?.Latitude;
-    const lng = sourceFields?.Longitude;
+    const id = resolveProjectId(record, sourceFields);
+    const lat = sourceFields.Latitude;
+    const lng = sourceFields.Longitude;
 
     if (!id) {
       console.warn(

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -27,11 +27,7 @@ function resolveProjectState(sourceFields: Record<string, unknown>): string {
     .trim()
     .toLowerCase();
 
-  if (
-    rawState === "under construction" ||
-    rawState === "under_construction" ||
-    rawState === "construction"
-  ) {
+  if (["under construction", "under_construction", "construction"].includes(rawState)) {
     return "under construction";
   }
 
@@ -64,6 +60,7 @@ function resolveProjectId(
 ): number | undefined {
   return (
     resolveNumericId(record.id) ??
+    // Some NocoDB payloads expose the primary key as "Id" instead of "id".
     resolveNumericId(record.Id) ??
     resolveNumericId(sourceFields.id) ??
     resolveNumericId(sourceFields.Id)

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -63,12 +63,18 @@ function processProjectData(
 
   // Verwende eine for-Schleife statt map/filter für bessere Performance
   for (let i = 0; i < len; i++) {
-    const record = list[i];
+    const record = list[i] as RawProjectRecord & {
+      Id?: number;
+      [key: string]: unknown;
+    };
+    const sourceFields =
+      (record.fields as Record<string, unknown> | undefined) ||
+      (record as unknown as Record<string, unknown>);
 
     // Grundlegende Validierung - wir brauchen mindestens eine ID und Koordinaten
-    const id = record.id;
-    const lat = record.fields?.Latitude;
-    const lng = record.fields?.Longitude;
+    const id = record.id ?? record.Id;
+    const lat = sourceFields?.Latitude;
+    const lng = sourceFields?.Longitude;
 
     if (!id) {
       console.warn(
@@ -92,10 +98,10 @@ function processProjectData(
     const project: Project = {
       id: Number(id),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      name: ((record.fields as any)?.[nameField] || record.fields?.Name || "Unbenannt") as string,
+      name: ((sourceFields as any)?.[nameField] || sourceFields?.Name || "Unbenannt") as string,
       latitude: latNum,
       longitude: lngNum,
-      state: (record.fields?.State || "finished") as string,
+      state: ((sourceFields?.State as string) || (sourceFields?.Status as string) || "finished") as string,
       category: undefined,
       country: undefined,
       notes: undefined,
@@ -103,26 +109,26 @@ function processProjectData(
     };
 
     // Nur die notwendigen Felder für die Kartenansicht
-    if (record.fields?.Category && Array.isArray(record.fields.Category)) {
-      project.category = record.fields.Category;
+    if (sourceFields?.Category && Array.isArray(sourceFields.Category)) {
+      project.category = sourceFields.Category as Project["category"];
     }
 
     if (
-      record.fields?.Country &&
-      Array.isArray(record.fields.Country) &&
-      record.fields.Country.length > 0
+      sourceFields?.Country &&
+      Array.isArray(sourceFields.Country) &&
+      sourceFields.Country.length > 0
     ) {
-      project.country = record.fields.Country[0];
+      project.country = sourceFields.Country[0] as Project["country"];
     }
 
     // Nur die zusätzlichen Felder hinzufügen, wenn nicht nur für die Karte
     if (!forMapOnly) {
-      if (record.fields?.TeaserImage) {
-        project.teaserImg = record.fields.TeaserImage as Project["teaserImg"];
+      if (sourceFields?.TeaserImage) {
+        project.teaserImg = sourceFields.TeaserImage as Project["teaserImg"];
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rawNotes = ((record.fields as any)?.[notesField] || record.fields?.Notes) as string | undefined;
+      const rawNotes = ((sourceFields as any)?.[notesField] || sourceFields?.Notes) as string | undefined;
       if (rawNotes) {
         project.notes = rawNotes
           .replaceAll('"<http', '"http')
@@ -131,16 +137,16 @@ function processProjectData(
         project.notes = "";
       }
 
-      if (record.fields?.Link) {
-        project.link = record.fields.Link as string;
+      if (sourceFields?.Link) {
+        project.link = sourceFields.Link as string;
       }
 
-      if (record.fields?.Since) {
-        project.since = new Date(record.fields.Since as string);
+      if (sourceFields?.Since) {
+        project.since = new Date(sourceFields.Since as string);
       }
 
-      if (record.fields?.Gallery) {
-        project.gallery = record.fields.Gallery as Project["gallery"];
+      if (sourceFields?.Gallery) {
+        project.gallery = sourceFields.Gallery as Project["gallery"];
       }
     }
 

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -22,20 +22,52 @@ function resolveRecordFields(
 
 function resolveProjectState(sourceFields: Record<string, unknown>): string {
   // Some datasets expose this value as "State", others as legacy "Status".
-  // Default to "finished" only when both fields are missing/empty.
-  return (sourceFields.State || sourceFields.Status || "finished") as string;
+  // Normalize known variants so map grouping always receives supported values.
+  const rawState = String(sourceFields.State || sourceFields.Status || "")
+    .trim()
+    .toLowerCase();
+
+  if (
+    rawState === "under construction" ||
+    rawState === "under_construction" ||
+    rawState === "construction"
+  ) {
+    return "under construction";
+  }
+
+  if (rawState === "planned") {
+    return "planned";
+  }
+
+  // Default to "finished" when missing/unknown to keep pins visible.
+  return "finished";
+}
+
+function resolveNumericId(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
 }
 
 function resolveProjectId(
   record: RawProjectRecord,
   sourceFields: Record<string, unknown>,
 ): number | undefined {
-  if (typeof record.id === "number" && !Number.isNaN(record.id)) {
-    return record.id;
-  }
-  const altId = sourceFields.Id;
-  const altNum = Number(altId);
-  return Number.isFinite(altNum) ? altNum : undefined;
+  return (
+    resolveNumericId(record.id) ??
+    resolveNumericId(record.Id) ??
+    resolveNumericId(sourceFields.id) ??
+    resolveNumericId(sourceFields.Id)
+  );
 }
 
 // Cache-Gültigkeit (5 Minuten)
@@ -98,7 +130,7 @@ function processProjectData(
     const lat = sourceFields.Latitude;
     const lng = sourceFields.Longitude;
 
-    if (!id) {
+    if (id === undefined) {
       console.warn(
         `Skipping project due to missing ID. Record keys:`,
         Object.keys(record),

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -20,6 +20,11 @@ function resolveRecordFields(
   return record as unknown as Record<string, unknown>;
 }
 
+function resolveProjectState(sourceFields: Record<string, unknown>): string {
+  // Some datasets expose this value as "State", others as legacy "Status".
+  return (sourceFields.State || sourceFields.Status || "finished") as string;
+}
+
 // Cache-Gültigkeit (5 Minuten)
 const CACHE_VALIDITY_MS = 5 * 60 * 1000;
 
@@ -76,7 +81,7 @@ function processProjectData(
     const sourceFields = resolveRecordFields(record);
 
     // Grundlegende Validierung - wir brauchen mindestens eine ID und Koordinaten
-    const id = record.id ?? record.Id;
+    const id = record.id ?? Number(sourceFields.Id);
     const lat = sourceFields?.Latitude;
     const lng = sourceFields?.Longitude;
 
@@ -105,7 +110,7 @@ function processProjectData(
       name: ((sourceFields as any)?.[nameField] || sourceFields?.Name || "Unbenannt") as string,
       latitude: latNum,
       longitude: lngNum,
-      state: (sourceFields?.State || sourceFields?.Status || "finished") as string,
+      state: resolveProjectState(sourceFields),
       category: undefined,
       country: undefined,
       notes: undefined,

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -22,6 +22,7 @@ function resolveRecordFields(
 
 function resolveProjectState(sourceFields: Record<string, unknown>): string {
   // Some datasets expose this value as "State", others as legacy "Status".
+  // Default to "finished" only when both fields are missing/empty.
   return (sourceFields.State || sourceFields.Status || "finished") as string;
 }
 

--- a/src/features/projects/stores/project.store.ts
+++ b/src/features/projects/stores/project.store.ts
@@ -85,6 +85,8 @@ export const useProjectStore = defineStore("project", {
         this.mapProjects.length > 0 &&
         !this.shouldRefreshCache()
       ) {
+        // Sofort filteredList mit den vorhandenen Kartendaten füllen
+        this.filteredList = [...this.mapProjects];
         return this.mapProjects;
       }
 
@@ -106,6 +108,9 @@ export const useProjectStore = defineStore("project", {
           this.mapProjects = mapData;
           this.mapInitialized = true;
           this.lastFetched = Date.now();
+
+          // Sofort filteredList mit Kartendaten füllen für erste Rendering-Phase
+          this.filteredList = [...mapData];
 
           // Auch die Hauptprojektliste aktualisieren, wenn sie leer ist
           if (this.projects.length === 0) {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -14,7 +14,8 @@
     },
     "mapTypes": {
       "satellite": "Satellit",
-      "map": "Karte"
+      "map": "Karte",
+      "carto": "Minimal"
     },
     "chips": {
       "all": "Alle",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,7 +14,8 @@
     },
     "mapTypes": {
       "satellite": "Satellite",
-      "map": "Map"
+      "map": "Map",
+      "carto": "Minimal"
     },
     "chips": {
       "all": "All",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -14,7 +14,8 @@
     },
     "mapTypes": {
       "satellite": "Satellite",
-      "map": "Carte"
+      "map": "Carte",
+      "carto": "Minimale"
     },
     "chips": {
       "all": "Tous",

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,9 @@ const projectStore = useProjectStore(pinia);
 const categoryStore = useCategoryStore(pinia);
 const countryStore = useCountryStore(pinia);
 
+const TAXONOMY_IDLE_TIMEOUT_MS = 1200;
+const TAXONOMY_FALLBACK_DELAY_MS = 100;
+
 // Prioritize map data for first paint; defer taxonomy loading slightly so
 // markers can appear as early as possible.
 projectStore.preloadMapData().catch((err) => {
@@ -54,9 +57,9 @@ const loadTaxonomies = () => {
 };
 
 if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
-  window.requestIdleCallback(loadTaxonomies, { timeout: 1200 });
+  window.requestIdleCallback(loadTaxonomies, { timeout: TAXONOMY_IDLE_TIMEOUT_MS });
 } else {
-  setTimeout(loadTaxonomies, 100);
+  setTimeout(loadTaxonomies, TAXONOMY_FALLBACK_DELAY_MS);
 }
 
 // app.component('vue-picture-swipe', VuePictureSwipe)

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,13 +35,29 @@ const projectStore = useProjectStore(pinia);
 const categoryStore = useCategoryStore(pinia);
 const countryStore = useCountryStore(pinia);
 
-// Load all stores in parallel for faster initial load
-// Map data is prioritized as it's needed for the first render
-Promise.all([
-  projectStore.preloadMapData(),
-  categoryStore.load(),
-  countryStore.load(),
-]).catch((err) => console.error("Initial data load failed:", err));
+// Prioritize map data for first paint; defer taxonomy loading slightly so
+// markers can appear as early as possible.
+projectStore.preloadMapData().catch((err) => {
+  console.error("Initial map data load failed:", err);
+});
+
+const loadTaxonomies = () => {
+  Promise.allSettled([categoryStore.load(), countryStore.load()]).then(
+    (results) => {
+      results.forEach((result) => {
+        if (result.status === "rejected") {
+          console.error("Initial taxonomy load failed:", result.reason);
+        }
+      });
+    },
+  );
+};
+
+if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+  window.requestIdleCallback(loadTaxonomies, { timeout: 1200 });
+} else {
+  setTimeout(loadTaxonomies, 100);
+}
 
 // app.component('vue-picture-swipe', VuePictureSwipe)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,14 +35,13 @@ const projectStore = useProjectStore(pinia);
 const categoryStore = useCategoryStore(pinia);
 const countryStore = useCountryStore(pinia);
 
-// Start loading map data immediately, before any route is rendered
-projectStore
-  .preloadMapData()
-  .catch((err) => console.error("Map preload failed:", err));
-categoryStore
-  .load()
-  .catch((err) => console.error("Category load failed:", err));
-countryStore.load().catch((err) => console.error("Country load failed:", err));
+// Load all stores in parallel for faster initial load
+// Map data is prioritized as it's needed for the first render
+Promise.all([
+  projectStore.preloadMapData(),
+  categoryStore.load(),
+  countryStore.load(),
+]).catch((err) => console.error("Initial data load failed:", err));
 
 // app.component('vue-picture-swipe', VuePictureSwipe)
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -118,12 +118,11 @@ function handleProjectClick(projectId: number) {
 // Map data, categories and countries are loaded in main.ts in parallel.
 // On HomeView we still hydrate full project records in the background so
 // search/cards get complete data without delaying first map paint.
-type IdleCallbackHandle = number;
-let hydrationHandle: IdleCallbackHandle | null = null;
-const idleScheduler = globalThis as typeof globalThis & {
-  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
-  cancelIdleCallback?: (handle: number) => void;
-};
+const HYDRATION_IDLE_TIMEOUT_MS = 1500;
+const HYDRATION_FALLBACK_DELAY_MS = 150;
+
+let hydrationIdleRequestId: number | null = null;
+let hydrationTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
 function startBackgroundHydration() {
   const hydrate = () => {
@@ -132,12 +131,14 @@ function startBackgroundHydration() {
     });
   };
 
-  if (typeof idleScheduler.requestIdleCallback === "function") {
-    hydrationHandle = idleScheduler.requestIdleCallback(hydrate, { timeout: 1500 });
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    hydrationIdleRequestId = window.requestIdleCallback(hydrate, {
+      timeout: HYDRATION_IDLE_TIMEOUT_MS,
+    });
     return;
   }
 
-  hydrationHandle = setTimeout(hydrate, 0);
+  hydrationTimeoutHandle = setTimeout(hydrate, HYDRATION_FALLBACK_DELAY_MS);
 }
 
 // ── Keep search bar visible on mobile when the keyboard opens ──────────
@@ -198,13 +199,18 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  if (hydrationHandle !== null) {
-    if (typeof idleScheduler.cancelIdleCallback === "function") {
-      idleScheduler.cancelIdleCallback(hydrationHandle);
-    } else {
-      clearTimeout(hydrationHandle);
-    }
-    hydrationHandle = null;
+  if (
+    hydrationIdleRequestId !== null &&
+    typeof window !== "undefined" &&
+    typeof window.cancelIdleCallback === "function"
+  ) {
+    window.cancelIdleCallback(hydrationIdleRequestId);
+    hydrationIdleRequestId = null;
+  }
+
+  if (hydrationTimeoutHandle !== null) {
+    clearTimeout(hydrationTimeoutHandle);
+    hydrationTimeoutHandle = null;
   }
 
   document.documentElement.classList.remove(BODY_LOCK_CLASS);

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -115,54 +115,8 @@ function handleProjectClick(projectId: number) {
   navigateToProject(projectId);
 }
 
-// Map data, categories and countries are already loading in main.ts.
-// De-prioritize full project data so map render keeps network priority.
-// Keep full-detail load behind map paint but still trigger within short user-perceived delay.
-const FULL_PROJECT_IDLE_TIMEOUT_MS = 1500;
-const FULL_PROJECT_FALLBACK_DELAY_MS = 300;
-const idleWindow = window as Window & {
-  requestIdleCallback?: (
-    callback: (deadline: IdleDeadline) => void,
-    options?: { timeout: number },
-  ) => number;
-  cancelIdleCallback?: (handle: number) => void;
-};
-
-const fullProjectLoadTimeoutHandle = ref<number | null>(null);
-const fullProjectLoadIdleCallbackHandle = ref<number | null>(null);
-
-function clearDeferredProjectLoad() {
-  if (fullProjectLoadTimeoutHandle.value) {
-    clearTimeout(fullProjectLoadTimeoutHandle.value);
-    fullProjectLoadTimeoutHandle.value = null;
-  }
-  if (fullProjectLoadIdleCallbackHandle.value && idleWindow.cancelIdleCallback) {
-    idleWindow.cancelIdleCallback(fullProjectLoadIdleCallbackHandle.value);
-    fullProjectLoadIdleCallbackHandle.value = null;
-  }
-}
-
-function deferredFullProjectLoad() {
-  const loadProjects = () => {
-    projectStore
-      .load(false)
-      .catch((err) => console.error("Full project load failed:", err));
-  };
-
-  clearDeferredProjectLoad();
-  if (idleWindow.requestIdleCallback) {
-    fullProjectLoadIdleCallbackHandle.value = idleWindow.requestIdleCallback(() => {
-      loadProjects();
-      fullProjectLoadIdleCallbackHandle.value = null;
-    }, { timeout: FULL_PROJECT_IDLE_TIMEOUT_MS });
-    return;
-  }
-
-  fullProjectLoadTimeoutHandle.value = window.setTimeout(() => {
-    loadProjects();
-    fullProjectLoadTimeoutHandle.value = null;
-  }, FULL_PROJECT_FALLBACK_DELAY_MS);
-}
+// Map data, categories and countries are already loading in main.ts in parallel.
+// No need for deferred loading as filteredList is populated immediately by preloadMapData()
 
 // ── Keep search bar visible on mobile when the keyboard opens ──────────
 // On mobile the .home container is position:fixed;inset:0 so the map and
@@ -173,7 +127,7 @@ function deferredFullProjectLoad() {
 // An additional body lock (.body-locked on html+body) prevents iOS Safari
 // from scrolling the document when an input is focused — without this,
 // position:fixed elements can shift or disappear on iOS.
-// ────────────────────────────────────────────────────────────────────────
+// ──────────────────────────────────────────────────────────────────────
 
 const isSearchActive = ref(false);
 const mapContainerRef = ref<HTMLElement | null>(null);
@@ -210,7 +164,8 @@ const BODY_LOCK_CLASS = 'body-locked';
 const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
 onMounted(() => {
-  deferredFullProjectLoad();
+  // No need for deferredFullProjectLoad() anymore as filteredList is already populated
+  // by preloadMapData() in main.ts
 
   if (isMobile) {
     document.documentElement.classList.add(BODY_LOCK_CLASS);
@@ -222,8 +177,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  clearDeferredProjectLoad();
-
   document.documentElement.classList.remove(BODY_LOCK_CLASS);
   document.body.classList.remove(BODY_LOCK_CLASS);
   if (window.visualViewport) {
@@ -327,20 +280,8 @@ onUnmounted(() => {
     </div>
     
     <div class="project-map" id="project-map">
-      <!-- Map and data load in parallel: map tiles show immediately, pins appear when data is ready -->
-      <Suspense>
-        <template #default>
-          <location-map :filtered-projects="filteredList" :base-layer="baseLayer" />
-        </template>
-        <template #fallback>
-          <div class="map-loading">
-            <div class="spinner-border text-primary" role="status">
-              <span class="visually-hidden">{{ t("search.loadingMap") }}</span>
-            </div>
-            <p class="mt-2">{{ t("search.loadingMap") }}</p>
-          </div>
-        </template>
-      </Suspense>
+      <!-- Map loads immediately, markers load asynchronously via Suspense in LocationMap -->
+      <LocationMap :filtered-projects="filteredList" :base-layer="baseLayer" />
     </div>
   </div>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineAsyncComponent, ref, computed, onMounted, onUnmounted } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
 import { useRouter } from "vue-router";
@@ -27,14 +27,11 @@ const { countries } = storeToRefs(countryStore);
 // Derive local refs from shared filter store for template bindings
 const { stateFilter, categoryFilter, countryFilter, filterVisible } = storeToRefs(filterStore);
 
-// Start map chunk loading immediately so first map paint waits less.
-const locationMapLoader = import("../components/map/LocationMap.vue");
+// Load map synchronously to avoid delayed main thread rendering
+import LocationMap from "../components/map/LocationMap.vue";
 
-// Lazy-load the map component (Leaflet stays out of the initial bundle)
-const LocationMap = defineAsyncComponent(() => locationMapLoader);
-
-// Map base layer (satellite or OSM)
-const baseLayer = ref<'satellite' | 'osm'>('osm');
+// Map base layer (CartoDB, satellite or OSM)
+const baseLayer = ref<'satellite' | 'osm' | 'carto'>('carto');
 
 const stateOptions = computed(() => [
   { text: t("project.state.finished"), value: "finished" },
@@ -263,6 +260,15 @@ onUnmounted(() => {
               <IBiMap /> {{ t("search.filterGroups.mapType") }}
             </h6>
             <div class="map-type-toggle" role="group" :aria-label="t('search.filterGroups.mapType')">
+              <button
+                class="map-type-btn"
+                :class="{ active: baseLayer === 'carto' }"
+                :aria-pressed="baseLayer === 'carto'"
+                @click="baseLayer = 'carto'"
+              >
+                <IBiMap class="me-1" aria-hidden="true" />
+                {{ t("search.mapTypes.carto") }}
+              </button>
               <button
                 class="map-type-btn"
                 :class="{ active: baseLayer === 'satellite' }"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -115,8 +115,30 @@ function handleProjectClick(projectId: number) {
   navigateToProject(projectId);
 }
 
-// Map data, categories and countries are already loading in main.ts in parallel.
-// No need for deferred loading as filteredList is populated immediately by preloadMapData()
+// Map data, categories and countries are loaded in main.ts in parallel.
+// On HomeView we still hydrate full project records in the background so
+// search/cards get complete data without delaying first map paint.
+type IdleCallbackHandle = number;
+let hydrationHandle: IdleCallbackHandle | null = null;
+const idleScheduler = globalThis as typeof globalThis & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function startBackgroundHydration() {
+  const hydrate = () => {
+    projectStore.load(false).catch((error) => {
+      console.error("Background project hydration failed:", error);
+    });
+  };
+
+  if (typeof idleScheduler.requestIdleCallback === "function") {
+    hydrationHandle = idleScheduler.requestIdleCallback(hydrate, { timeout: 1500 });
+    return;
+  }
+
+  hydrationHandle = setTimeout(hydrate, 0);
+}
 
 // ── Keep search bar visible on mobile when the keyboard opens ──────────
 // On mobile the .home container is position:fixed;inset:0 so the map and
@@ -164,8 +186,7 @@ const BODY_LOCK_CLASS = 'body-locked';
 const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
 onMounted(() => {
-  // No need for deferredFullProjectLoad() anymore as filteredList is already populated
-  // by preloadMapData() in main.ts
+  startBackgroundHydration();
 
   if (isMobile) {
     document.documentElement.classList.add(BODY_LOCK_CLASS);
@@ -177,6 +198,15 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  if (hydrationHandle !== null) {
+    if (typeof idleScheduler.cancelIdleCallback === "function") {
+      idleScheduler.cancelIdleCallback(hydrationHandle);
+    } else {
+      clearTimeout(hydrationHandle);
+    }
+    hydrationHandle = null;
+  }
+
   document.documentElement.classList.remove(BODY_LOCK_CLASS);
   document.body.classList.remove(BODY_LOCK_CLASS);
   if (window.visualViewport) {


### PR DESCRIPTION
Initial HomeView load still prioritized non-critical work, delaying first meaningful map paint, and marker data could be dropped during normalization, resulting in empty maps. This PR reorders startup sequencing for map-first rendering and hardens project parsing so pins consistently render.

- **Map-first startup sequencing**
  - `main.ts` now starts `projectStore.preloadMapData()` immediately.
  - Category/country loads are deferred to idle time (with short timeout fallback) to reduce contention during first map render.

- **Project record normalization hardening**
  - `project.service.ts` now resolves IDs from multiple payload variants (`id`, `Id`, nested `fields`) and supports numeric strings.
  - Missing/variant IDs no longer cause valid map records to be skipped.

- **State normalization for stable marker grouping**
  - Project state values are normalized to supported groups (`finished`, `under construction`, `planned`) before grouping/rendering.
  - Common aliases (e.g. `under_construction`, `construction`) are mapped to the expected marker bucket.

```ts
function resolveProjectId(record, sourceFields) {
  return (
    resolveNumericId(record.id) ??
    resolveNumericId(record.Id) ??
    resolveNumericId(sourceFields.id) ??
    resolveNumericId(sourceFields.Id)
  );
}

projectStore.preloadMapData();
window.requestIdleCallback?.(loadTaxonomies, { timeout: TAXONOMY_IDLE_TIMEOUT_MS });
```