### PR TITLE
fix: a11y i18n improvements — hardcoded labels, focus trap, German text

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ export default [
       "vue/require-default-prop": "off",
       "vue/no-multiple-template-root": "off",
       "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
   ...tseslint.configs.recommended,

--- a/netlify/functions/sitemap.mjs
+++ b/netlify/functions/sitemap.mjs
@@ -101,7 +101,7 @@ ${urlElements}
 
 // ── Handler ─────────────────────────────────────────────────────────
 
-export default async (req, context) => {
+export default async (_req, _context) => {
   // CORS headers for direct access
   const headers = {
     "Content-Type": "application/xml; charset=utf-8",

--- a/src/components/SearchModal.vue
+++ b/src/components/SearchModal.vue
@@ -82,10 +82,10 @@
     <div v-if="results.length > 0" class="search-footer px-4 py-2 d-flex align-items-center gap-3 text-muted small border-top">
       <span aria-hidden="true"><kbd>↵</kbd> öffnen</span>
       <span aria-hidden="true"><kbd>Esc</kbd> schließen</span>
-      <span class="ms-auto" aria-live="polite">{{ results.length }} Ergebnis(se)</span>
+      <span class="ms-auto" aria-live="polite">{{ t("a11y.searchResultsAnnouncement", { count: results.length }) }}</span>
     </div>
     <div class="sr-only" role="status" aria-live="polite">
-      {{ results.length > 0 ? `${results.length} Ergebnisse gefunden` : (query.length >= 2 ? 'Keine Ergebnisse gefunden' : '') }}
+      {{ results.length > 0 ? t("a11y.searchResultsAnnouncement", { count: results.length }) : (query.length >= 2 ? t("a11y.noResultsAnnouncement") : '') }}
     </div>
   </b-modal>
 </template>

--- a/src/components/actions/NavigateButton.vue
+++ b/src/components/actions/NavigateButton.vue
@@ -1,36 +1,28 @@
 <template>
   <b-button
-    title="Navigate"
-    aria-label="Navigate"
+    :title="t('nav.navigate')"
+    :aria-label="t('nav.navigate')"
     @click="navigate"
     class="navigate-button d-flex align-items-center justify-content-center"
   >
     <IBiPinMapFill /> Navigate &hellip;
   </b-button>
 </template>
-<script lang="ts">
-import { defineComponent } from "vue";
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
 
-export default defineComponent({
-  name: "NavigateButton",
-  props: {
-    lat: {
-      type: Number,
-      required: true,
-    },
-    lng: {
-      type: Number,
-      required: true,
-    },
-  },
-  methods: {
-    navigate() {
-      window.open(
-        `https://www.google.com/maps/search/?api=1&query=${this.lat},${this.lng}`,
-      );
-    },
-  },
-});
+const { t } = useI18n();
+
+const props = defineProps<{
+  lat: number;
+  lng: number;
+}>();
+
+function navigate() {
+  window.open(
+    `https://www.google.com/maps/search/?api=1&query=${props.lat},${props.lng}`,
+  );
+}
 </script>
 <style lang="scss" scoped>
 @use "@/assets/design-tokens.scss" as *;

--- a/src/components/actions/ShareButton.vue
+++ b/src/components/actions/ShareButton.vue
@@ -1,56 +1,37 @@
 <template>
   <b-button
     v-if="isShareable"
-    title="Share this Page"
-    aria-label="Share this Page"
+    :title="t('nav.share')"
+    :aria-label="t('nav.share')"
     @click="shareDetails"
     class="share-button d-flex align-items-center justify-content-center"
   >
     <IBiShareFill /> Share &hellip;
   </b-button>
 </template>
-<script lang="ts">
-import { defineComponent } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 
-export default defineComponent({
-  name: "ShareButton",
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    text: {
-      type: String,
-      required: true,
-    },
-    url: {
-      type: String,
-      required: true,
-    },
-    fixed: {
-      type: Boolean,
-      default: true,
-    },
-  },
-  computed: {
-    isShareable() {
-      return "share" in navigator;
-    },
-  },
-  methods: {
-    shareDetails() {
-      if (!this.isShareable) {
-        return;
-      }
-      const data = {
-        title: this.title,
-        text: this.text,
-        url: this.url,
-      };
-      navigator.share(data);
-    },
-  },
-});
+const { t } = useI18n();
+
+const props = defineProps<{
+  title: string;
+  text: string;
+  url: string;
+  fixed?: boolean;
+}>();
+
+const isShareable = computed(() => "share" in navigator);
+
+function shareDetails() {
+  if (!isShareable.value) return;
+  navigator.share({
+    title: props.title,
+    text: props.text,
+    url: props.url,
+  });
+}
 </script>
 <style lang="scss" scoped>
 @use "@/assets/design-tokens.scss" as *;

--- a/src/components/project/ProjectGallery.vue
+++ b/src/components/project/ProjectGallery.vue
@@ -7,7 +7,7 @@
         class="gallery-item teaser-item"
         role="button"
         tabindex="0"
-        :aria-label="'Open ' + (project.teaserImg[0].name || 'teaser image')"
+        :aria-label="t('a11y.openImage', { name: project.teaserImg[0].name || t('a11y.imageNotAvailable') })"
         @click="openModal(project.teaserImg[0])"
         @keydown.enter="openModal(project.teaserImg[0])"
         @keydown.space.prevent="openModal(project.teaserImg[0])"
@@ -28,7 +28,7 @@
         class="gallery-item"
         role="button"
         tabindex="0"
-        :aria-label="'Open ' + (item.name || 'gallery item')"
+        :aria-label="t('a11y.openImage', { name: item.name || t('a11y.imageNotAvailable') })"
         @click="openModal(item)"
         @keydown.enter="openModal(item)"
         @keydown.space.prevent="openModal(item)"
@@ -71,58 +71,43 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, ref, computed } from 'vue';
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import type { Project } from '@/interfaces/Project';
+import type { Attachment } from '@/interfaces/Attachment';
 import ProjectGalleryModal from './ProjectGalleryModal.vue';
 
-export default defineComponent({
-  name: 'ProjectGallery',
-  components: {
-    ProjectGalleryModal
-  },
-  props: {
-    project: {
-      type: Object as PropType<Project>,
-      required: true
-    },
-    title: {
-      type: String,
-      default: "Gallery"
-    }
-  },
-  setup(props) {
-    const modalVisible = ref(false);
-    const currentItem = ref(null);
-    const imageError = ref(false);
+const { t } = useI18n();
 
-    const galleryWithTeaserImg = computed(() => {
-      const gallery = props.project.gallery || [];
-      const teaserImg = props.project.teaserImg ? [props.project.teaserImg[0]] : [];
-      return [...teaserImg, ...gallery];
-    });
+const props = defineProps<{
+  project: Project;
+  title?: string;
+}>();
 
-    return {
-      modalVisible,
-      currentItem,
-      galleryWithTeaserImg,
-      imageError,
-    };
-  },
-  methods: {
-    openModal(item: any) {
-      this.currentItem = item;
-      this.modalVisible = true;
-    },
-    closeModal() {
-      this.modalVisible = false;
-      this.currentItem = null;
-    },
-    onImageError() {
-      this.imageError = true;
-    },
-  }
+const modalVisible = ref(false);
+const currentItem = ref<Attachment | null>(null);
+const imageError = ref(false);
+
+const galleryWithTeaserImg = computed(() => {
+  const gallery = props.project.gallery || [];
+  const teaserImg = props.project.teaserImg ? [props.project.teaserImg[0]] : [];
+  return [...teaserImg, ...gallery];
 });
+
+function openModal(item: Attachment) {
+  currentItem.value = item;
+  modalVisible.value = true;
+}
+
+function closeModal() {
+  modalVisible.value = false;
+  currentItem.value = null;
+}
+
+function onImageError() {
+  imageError.value = true;
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/project/ProjectGalleryModal.vue
+++ b/src/components/project/ProjectGalleryModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="props.isVisible" class="fullscreen-gallery" role="dialog" :aria-label="t('a11y.closeGallery')" tabindex="0" @keydown="onKeydown">
+  <div v-if="props.isVisible" ref="galleryRef" class="fullscreen-gallery" role="dialog" :aria-label="t('a11y.closeGallery')" tabindex="0" @keydown="onKeydown">
     <button class="gallery-close" @click="closeModal" :aria-label="t('a11y.closeGallery')">
       <span aria-hidden="true">&times;</span>
     </button>
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Attachment } from '@/interfaces/Attachment'
 import { useFocusRestore } from '@/composables/useAccessibility'
@@ -141,7 +141,27 @@ function closeModal() {
   emit('update:isVisible', false)
 }
 
+const galleryRef = ref<HTMLElement | null>(null)
+
+function trapFocus(e: KeyboardEvent) {
+  if (e.key !== 'Tab' || !galleryRef.value) return
+  const focusable = galleryRef.value.querySelectorAll<HTMLElement>(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+  )
+  if (focusable.length === 0) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
 function onKeydown(e: KeyboardEvent) {
+  trapFocus(e)
   if (e.key === 'ArrowLeft') {
     e.preventDefault()
     goPrev()
@@ -174,9 +194,15 @@ watch(
 // Capture focus when modal opens, restore when it closes
 watch(
   () => props.isVisible,
-  (visible) => {
+  async (visible) => {
     if (visible) {
       setTrigger()
+      await nextTick()
+      // Focus first focusable element inside the modal (close button)
+      const firstFocusable = galleryRef.value?.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      firstFocusable?.focus()
     } else {
       restoreFocus()
     }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -42,7 +42,9 @@
     "list": "Liste",
     "about": "Über uns",
     "more": "Mehr",
-    "close": "Schließen"
+    "close": "Schließen",
+    "navigate": "Navigieren",
+    "share": "Teilen"
   },
   "common": {
     "close": "Schließen"
@@ -95,6 +97,7 @@
     "closeGallery": "Galerie schließen",
     "closeAbout": "Über-Dialog schließen",
     "imageNotAvailable": "Bild nicht verfügbar",
+    "openImage": "Öffnen {name}",
     "imagePosition": "Bild {current} von {total}",
     "zoomIn": "Vergrößern",
     "zoomOut": "Verkleinern",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,7 +42,9 @@
     "list": "List",
     "about": "About",
     "more": "More",
-    "close": "Close"
+    "close": "Close",
+    "navigate": "Navigate",
+    "share": "Share"
   },
   "common": {
     "close": "Close"
@@ -95,6 +97,7 @@
     "closeGallery": "Close gallery",
     "closeAbout": "Close about dialog",
     "imageNotAvailable": "Image not available",
+    "openImage": "Open {name}",
     "imagePosition": "Image {current} of {total}",
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -42,7 +42,9 @@
     "list": "Liste",
     "about": "À propos",
     "more": "Plus",
-    "close": "Fermer"
+    "close": "Fermer",
+    "navigate": "Naviguer",
+    "share": "Partager"
   },
   "common": {
     "close": "Fermer"
@@ -95,6 +97,7 @@
     "closeGallery": "Fermer la galerie",
     "closeAbout": "Fermer la boîte de dialogue À propos",
     "imageNotAvailable": "Image non disponible",
+    "openImage": "Ouvrir {name}",
     "imagePosition": "Image {current} sur {total}",
     "zoomIn": "Zoom avant",
     "zoomOut": "Zoom arrière",


### PR DESCRIPTION
## A11y & i18n fixes

### High Priority
- **NavigateButton**: `title`/`aria-label` now use `t('nav.navigate')` instead of hardcoded "Navigate"
- **ShareButton**: `title`/`aria-label` now use `t('nav.share')` instead of hardcoded "Share this Page"
- Both migrated from Options API to `<script setup>` with `useI18n()`

### Medium Priority
- **SearchModal**: Result count + `sr-only` announcement now use translation keys instead of hardcoded German
- **ProjectGalleryModal**: Added focus trap (Tab/Shift+Tab cycles within modal, auto-focus on open)
- **ProjectGallery**: `aria-label` on gallery items uses `a11y.openImage` with `{name}` parameter; migrated to `<script setup>`
- Added `nav.navigate`, `nav.share`, `a11y.openImage` keys to all 3 locale files (de, en, fr)

### Verification
- ✅ `vue-tsc --noEmit` passes
- ✅ `vite build` succeeds