### PR TITLE
feat: ProjectDetailView header matches ProjectListView style and scroll behavior

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ export default [
       "vue/require-default-prop": "off",
       "vue/no-multiple-template-root": "off",
       "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
   ...tseslint.configs.recommended,

--- a/netlify/functions/sitemap.mjs
+++ b/netlify/functions/sitemap.mjs
@@ -101,7 +101,7 @@ ${urlElements}
 
 // ── Handler ─────────────────────────────────────────────────────────
 
-export default async (req, context) => {
+export default async (_req, _context) => {
   // CORS headers for direct access
   const headers = {
     "Content-Type": "application/xml; charset=utf-8",

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="project-page">
     <!-- Sticky header bar: back button + project title -->
-    <div class="page-header-sticky">
+    <div class="page-header-sticky" :class="{ 'header-scrolled': headerScrolled }">
       <b-container>
         <b-placeholder-wrapper :loading="loading">
           <template #loading>
@@ -177,7 +177,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeMount } from "vue";
+import { computed, onBeforeMount, onMounted, onUnmounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useProjectStore } from "@/features/projects/stores/project.store";
 import { useCategoryStore } from "@/stores/category.store";
@@ -202,6 +202,22 @@ import "leaflet/dist/leaflet.css";
 const { isIFrame } = useWebFrame();
 const { t, locale } = useI18n();
 const router = useRouter();
+
+// Collapse the sticky header when scrolled past the heading
+const SCROLL_THRESHOLD = 20;
+const headerScrolled = ref(false);
+
+function onScroll() {
+  headerScrolled.value = window.scrollY > SCROLL_THRESHOLD;
+}
+
+onMounted(() => {
+  window.addEventListener("scroll", onScroll, { passive: true });
+});
+
+onUnmounted(() => {
+  window.removeEventListener("scroll", onScroll);
+});
 
 const MarkdownText = defineAsyncComponent(
   () => import("@/components/MarkdownText.vue"),
@@ -321,24 +337,38 @@ const detailMarkerIcon = computed(() => {
 .page-header-sticky {
   position: sticky;
   top: 0;
-  z-index: 100;
-  background-color: var(--jws-bg-subtle, #f8f9fa);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-}
+  z-index: 50;
+  background: rgba(248, 249, 250, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+  transition: padding 0.3s ease, box-shadow 0.3s ease;
 
+  &.header-scrolled {
+    padding-top: 0.2rem;
+    padding-bottom: 0.1rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+
+    .title {
+      font-size: 1rem;
+      padding: 0;
+      line-height: 1.3;
+    }
+  }
+}
 
 .page-header {
   .title {
-    font-size: 2.75rem;
-    font-weight: 800;
+    font-size: 1.5rem;
+    font-weight: 700;
     color: var(--jws-primary);
-    letter-spacing: -0.03em;
-    line-height: 1.1;
-    
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+    transition: all 0.3s ease;
+
     @media (max-width: 768px) {
-      font-size: 1.75rem;
+      font-size: 1.25rem;
+      padding: 0.375rem 0;
     }
   }
 }


### PR DESCRIPTION
## Summary

Makes the sticky header on ProjectDetailView match the style and scroll behavior of ProjectListView.

### Changes

- **Collapsible on scroll** — scroll listener with `SCROLL_THRESHOLD=20` toggles `header-scrolled` class, shrinking the heading
- **Consistent glassmorphism** — `rgba(248,249,250,0.85)` background + `backdrop-filter: blur(12px)` (was `bg-subtle + blur(10px)`)
- **Aligned title sizing** — Desktop: `1.5rem` (was `2.75rem`), Mobile: `1.25rem` (was `1.75rem`), Collapsed: `1rem`
- **Softer bottom edge** — replaced `border-bottom` with `box-shadow: 0 1px 2px rgba(0,0,0,0.03)` matching ListView
- **Smooth transitions** — padding, box-shadow, and font-size animate on scroll

### Before/After

| | Before | After |
|---|---|---|
| Desktop title | 2.75rem, font-weight 800 | 1.5rem, font-weight 700 |
| Mobile title | 1.75rem | 1.25rem |
| Collapsed title | — (no collapse) | 1rem |
| Bottom edge | border-bottom | box-shadow |
| Glassmorphism | blur(10px) | blur(12px) |
| z-index | 100 | 50 (matching ListView)