### PR TITLE
fix: make filter panel scrollable on mobile so country list isn't clipped behind menu bar

### DIFF
--- a/src/views/ProjectListView.vue
+++ b/src/views/ProjectListView.vue
@@ -365,6 +365,8 @@ onBeforeMount(() => {
     left: 0;
     right: 0;
     z-index: 50;
+    max-height: 60vh;
+    overflow-y: auto;
   }
 }
 
@@ -435,6 +437,7 @@ onBeforeMount(() => {
     position: relative;
     z-index: 1000;
     max-height: min(50vh, 24rem);
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
## Problem

Auf mobilen Geräten hat `.filter-scroll` im Filter-Panel `overflow: hidden`. Sobald die Länderliste länger ist als `max-height: min(50vh, 24rem)`, wird der untere Teil abgeschnitten — die Länder verschwinden hinter der fixierten Menüleiste.

## Fix

`overflow: hidden` → `overflow-y: auto` in `.filter-scroll` (FilterPanel.vue).
Damit scrollt der gesamte Filter-Inhalt vertikal bei Überlauf, sodass alle Länder erreichbar bleiben.