### PR TITLE
refactor: add shared constants for project states

### DIFF
--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -79,6 +79,7 @@ import { ref, computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import type { ProjectState } from "@/composables/useProjectSearch";
+import { PROJECT_STATES } from "@/constants/projectStates";
 
 import IBiMap from "~icons/bi/map";
 import IBiListUl from "~icons/bi/list-ul";
@@ -141,9 +142,9 @@ const resolvedFilterLabel = computed(() => props.filterLabel || t("search.filter
 
 const stateOptions = computed(() => [
   { value: "all" as ProjectState, label: t("search.chips.all") },
-  { value: "planned" as ProjectState, label: t("search.chips.planned") },
-  { value: "under construction" as ProjectState, label: t("search.chips.underConstruction") },
-  { value: "finished" as ProjectState, label: t("search.chips.finished") },
+  { value: PROJECT_STATES.PLANNED as ProjectState, label: t("search.chips.planned") },
+  { value: PROJECT_STATES.UNDER_CONSTRUCTION as ProjectState, label: t("search.chips.underConstruction") },
+  { value: PROJECT_STATES.FINISHED as ProjectState, label: t("search.chips.finished") },
 ]);
 
 // Handle filter-chip click: update local state + emit both events (Codex #P2)

--- a/src/components/StateBadge.vue
+++ b/src/components/StateBadge.vue
@@ -7,6 +7,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { PROJECT_STATES } from "@/constants/projectStates";
 
 const { t } = useI18n();
 
@@ -16,9 +17,9 @@ const props = withDefaults(defineProps<{
 }>(), {});
 
 const stateKeyMap: Record<string, string> = {
-  finished: "finished",
-  "under construction": "underConstruction",
-  planned: "planned",
+  [PROJECT_STATES.FINISHED]: "finished",
+  [PROJECT_STATES.UNDER_CONSTRUCTION]: "underConstruction",
+  [PROJECT_STATES.PLANNED]: "planned",
 };
 
 const cssClass = computed(() => props.state.replace(" ", "-"));

--- a/src/components/map/LocationMap.vue
+++ b/src/components/map/LocationMap.vue
@@ -60,7 +60,7 @@
             ></l-icon>
             <l-tooltip v-if="zoom > 7">
               <span>{{ loc.name }}</span>
-              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+              <span v-if="loc.state !== PROJECT_STATES.FINISHED"> ({{ loc.state }})</span>
             </l-tooltip>
           </l-marker>
         </component>
@@ -86,7 +86,7 @@
             ></l-icon>
             <l-tooltip v-if="zoom > 7">
               <span>{{ loc.name }}</span>
-              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+              <span v-if="loc.state !== PROJECT_STATES.FINISHED"> ({{ loc.state }})</span>
             </l-tooltip>
           </l-marker>
         </component>
@@ -112,7 +112,7 @@
             ></l-icon>
             <l-tooltip v-if="zoom > 7">
               <span>{{ loc.name }}</span>
-              <span v-if="loc.state !== 'finished'"> ({{ loc.state }})</span>
+              <span v-if="loc.state !== PROJECT_STATES.FINISHED"> ({{ loc.state }})</span>
             </l-tooltip>
           </l-marker>
         </component>
@@ -143,6 +143,7 @@ import projectService from "@/features/projects/services/project.service";
 import type { Project } from "@/interfaces/Project";
 import { useI18n } from "vue-i18n";
 import { announceToScreenReader } from "@/composables/useAccessibility";
+import { PROJECT_STATES } from "@/constants/projectStates";
 
 // Lazy load Leaflet and related components
 const isLeafletLoaded = ref(false);
@@ -253,13 +254,13 @@ const mapOptions = {
 
 // Compute project lists from the filtered locations
 const projectsFinished = computed(() =>
-  locations.value.filter((p) => p.state === "finished"),
+  locations.value.filter((p) => p.state === PROJECT_STATES.FINISHED),
 );
 const projectsUnderConstruction = computed(() =>
-  locations.value.filter((p) => p.state === "under construction"),
+  locations.value.filter((p) => p.state === PROJECT_STATES.UNDER_CONSTRUCTION),
 );
 const projectsPlanned = computed(() =>
-  locations.value.filter((p) => p.state === "planned"),
+  locations.value.filter((p) => p.state === PROJECT_STATES.PLANNED),
 );
 
 const layerLabelProjectsFinished = computed(() =>

--- a/src/components/project/ProjectListItem.vue
+++ b/src/components/project/ProjectListItem.vue
@@ -73,6 +73,7 @@ import type { Project } from "@/interfaces/Project";
 import CategoryBadge from "../CategoryBadge.vue";
 import CountryLabel from "../CountryLabel.vue";
 import StateBadge from "@/components/StateBadge.vue";
+import { PROJECT_STATES } from "@/constants/projectStates";
 
 const { t } = useI18n();
 const { isIFrame, notifyNavigate } = useWebFrame();
@@ -103,9 +104,9 @@ const teaserImage = computed(() => {
 });
 
 const stateLabels: Record<string, string> = {
-  finished: t("project.state.finished"),
-  "under construction": t("project.state.underConstruction"),
-  planned: t("project.state.planned"),
+  [PROJECT_STATES.FINISHED]: t("project.state.finished"),
+  [PROJECT_STATES.UNDER_CONSTRUCTION]: t("project.state.underConstruction"),
+  [PROJECT_STATES.PLANNED]: t("project.state.planned"),
 };
 
 const cardAriaLabel = computed(() => {

--- a/src/composables/useProjectSearch.ts
+++ b/src/composables/useProjectSearch.ts
@@ -4,7 +4,7 @@ import type { Project } from "@/interfaces/Project";
 
 const DEFAULT_MAX_RESULTS = 20;
 
-export type ProjectState = "all" | "planned" | "under construction" | "finished";
+export type ProjectState = "all" | import("@/constants/projectStates").ProjectState;
 
 export function useProjectSearch(projects: Ref<Project[]>, options?: { limit?: number }) {
   const query = ref("");

--- a/src/constants/projectStates.ts
+++ b/src/constants/projectStates.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared constants for project lifecycle states.
+ *
+ * Centralises the "finished", "planned", "under construction" magic strings
+ * that were previously scattered across stores, services, composables, views,
+ * and components.  Using these constants instead of raw strings prevents
+ * typos, enables autocompletion, and makes future renaming safe.
+ */
+
+export const PROJECT_STATES = {
+  FINISHED: "finished" as const,
+  UNDER_CONSTRUCTION: "under construction" as const,
+  PLANNED: "planned" as const,
+} as const;
+
+/** Union type of all valid project states */
+export type ProjectState = (typeof PROJECT_STATES)[keyof typeof PROJECT_STATES];
+
+/** Array of all valid states — useful for iteration, validation, etc. */
+export const ALL_PROJECT_STATES: readonly ProjectState[] = Object.values(
+  PROJECT_STATES,
+);
+
+/**
+ * Determine whether a raw value is a known project state.
+ */
+export function isValidProjectState(value: string): value is ProjectState {
+  return ALL_PROJECT_STATES.includes(value as ProjectState);
+}
+
+/**
+ * Normalise a raw state string from NocoDB into a canonical ProjectState.
+ *
+ * Accepts common variants (e.g. "under_construction", "construction") and
+ * falls back to PROJECT_STATES.FINISHED for unknown values.
+ */
+export function normaliseProjectState(raw: string): ProjectState {
+  const trimmed = raw.trim().toLowerCase();
+
+  if (
+    trimmed === PROJECT_STATES.UNDER_CONSTRUCTION ||
+    trimmed === "under_construction" ||
+    trimmed === "construction"
+  ) {
+    return PROJECT_STATES.UNDER_CONSTRUCTION;
+  }
+
+  if (trimmed === PROJECT_STATES.PLANNED) {
+    return PROJECT_STATES.PLANNED;
+  }
+
+  return PROJECT_STATES.FINISHED;
+}

--- a/src/features/projects/services/project.service.ts
+++ b/src/features/projects/services/project.service.ts
@@ -2,7 +2,8 @@ import { projectRepository } from "@/features/projects/repositories/project.repo
 import type { Project } from "@/interfaces/Project";
 import type { LatLng } from "leaflet";
 import type { RawProjectRecord } from "@/features/projects/repositories/project.repository";
-import { i18n } from "@/plugins/i18n";
+import { currentLocale } from "@/utils/locale";
+import { normaliseProjectState } from "@/constants/projectStates";
 
 function resolveRecordFields(record: RawProjectRecord): Record<string, unknown> {
   if (record.fields && typeof record.fields === "object") {
@@ -12,19 +13,8 @@ function resolveRecordFields(record: RawProjectRecord): Record<string, unknown> 
 }
 
 function resolveProjectState(sourceFields: Record<string, unknown>): string {
-  const rawState = String(sourceFields.State || sourceFields.Status || "")
-    .trim()
-    .toLowerCase();
-
-  if (["under construction", "under_construction", "construction"].includes(rawState)) {
-    return "under construction";
-  }
-
-  if (rawState === "planned") {
-    return "planned";
-  }
-
-  return "finished";
+  const rawState = String(sourceFields.State || sourceFields.Status || "").trim();
+  return normaliseProjectState(rawState);
 }
 
 function resolveNumericId(value: unknown): number | undefined {
@@ -53,16 +43,6 @@ function resolveProjectId(
     resolveNumericId(sourceFields.id) ??
     resolveNumericId(sourceFields.Id)
   );
-}
-
-function currentLocale(): string {
-  try {
-    const loc = (i18n.global.locale as unknown as { value: string }).value;
-    if (loc && typeof loc === "string") return loc;
-  } catch {
-    // ignore
-  }
-  return "en";
 }
 
 function processProjectData(records: RawProjectRecord[]): Array<Project> {

--- a/src/features/projects/stores/project.store.ts
+++ b/src/features/projects/stores/project.store.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { PROJECT_STATES } from "@/constants/projectStates";
 import projectService from "@/features/projects/services/project.service";
 import { useLoadingStore } from "@/stores/loading.store";
 import type { Project } from "@/interfaces/Project";
@@ -24,29 +25,25 @@ export const useProjectStore = defineStore("project", {
       state.projects.find((project: Project) => project.id === id) as Project,
     projectsByState: (
       state,
-    ): {
-      finished: Project[];
-      "under construction": Project[];
-      planned: Project[];
-    } => {
-      const result = {
-        finished: [] as Project[],
-        "under construction": [] as Project[],
-        planned: [] as Project[],
+    ): Record<string, Project[]> => {
+      const result: Record<string, Project[]> = {
+        [PROJECT_STATES.FINISHED]: [],
+        [PROJECT_STATES.UNDER_CONSTRUCTION]: [],
+        [PROJECT_STATES.PLANNED]: [],
       };
       state.projects.forEach((project) => {
-        if (project.state && result[project.state as keyof typeof result]) {
-          result[project.state as keyof typeof result].push(project);
+        if (project.state && result[project.state]) {
+          result[project.state].push(project);
         }
       });
       return result;
     },
     projectsFinished: (state): Project[] =>
-      state.projects.filter((p) => p.state === "finished"),
+      state.projects.filter((p) => p.state === PROJECT_STATES.FINISHED),
     projectsUnderConstruction: (state): Project[] =>
-      state.projects.filter((p) => p.state === "under construction"),
+      state.projects.filter((p) => p.state === PROJECT_STATES.UNDER_CONSTRUCTION),
     projectsPlanned: (state): Project[] =>
-      state.projects.filter((p) => p.state === "planned"),
+      state.projects.filter((p) => p.state === PROJECT_STATES.PLANNED),
   },
   actions: {
     async load(): Promise<void> {

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,0 +1,19 @@
+import { i18n, type Locale } from "@/plugins/i18n";
+
+/**
+ * Resolve the current active locale from the vue-i18n instance.
+ *
+ * Centralises the awkward `i18n.global.locale as unknown as { value: string }`
+ * cast that was previously duplicated across stores and services.
+ *
+ * Falls back to "en" when the locale cannot be read.
+ */
+export function currentLocale(): Locale {
+  try {
+    const loc = (i18n.global.locale as unknown as { value: string }).value;
+    if (loc && typeof loc === "string") return loc as Locale;
+  } catch {
+    // i18n may not be initialised yet during eager store setup
+  }
+  return "en";
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -9,6 +9,7 @@ import { useCategoryStore } from "../stores/category.store";
 import { useCountryStore } from "../stores/country.store";
 import { useFilterStore } from "../stores/filter.store";
 import { useProjectSearch, type ProjectState } from "@/composables/useProjectSearch";
+import { PROJECT_STATES } from "@/constants/projectStates";
 import FilterPanel from "@/components/FilterPanel.vue";
 import MainMenu from "../components/MainMenu.vue";
 const LocationMap = defineAsyncComponent(() => import("../components/map/LocationMap.vue"));
@@ -35,9 +36,9 @@ const baseLayer = ref<'satellite' | 'osm' | 'carto'>('carto');
 const clusterEnabled = ref(false);
 
 const stateOptions = computed(() => [
-  { text: t("project.state.finished"), value: "finished" },
-  { text: t("project.state.underConstruction"), value: "under construction" },
-  { text: t("project.state.planned"), value: "planned" },
+  { text: t("project.state.finished"), value: PROJECT_STATES.FINISHED },
+  { text: t("project.state.underConstruction"), value: PROJECT_STATES.UNDER_CONSTRUCTION },
+  { text: t("project.state.planned"), value: PROJECT_STATES.PLANNED },
 ]);
 
 // Fuzzy search on the store's filtered list

--- a/src/views/ProjectListView.vue
+++ b/src/views/ProjectListView.vue
@@ -103,6 +103,7 @@ import { useFilterStore } from "../stores/filter.store";
 import type { Project } from "@/interfaces/Project";
 import ProjectListItem from "../components/project/ProjectListItem.vue";
 import { useProjectSearch, type ProjectState } from "@/composables/useProjectSearch";
+import { PROJECT_STATES } from "@/constants/projectStates";
 import FilterPanel from "@/components/FilterPanel.vue";
 import MainMenu from "../components/MainMenu.vue";
 import { projectRoute } from "@/utils/slug";
@@ -139,9 +140,9 @@ const finalProjectList = computed(() => {
 });
 
 const stateOptions = computed(() => [
-  { text: t("project.state.finished"), value: "finished" },
-  { text: t("project.state.underConstruction"), value: "under construction" },
-  { text: t("project.state.planned"), value: "planned" },
+  { text: t("project.state.finished"), value: PROJECT_STATES.FINISHED },
+  { text: t("project.state.underConstruction"), value: PROJECT_STATES.UNDER_CONSTRUCTION },
+  { text: t("project.state.planned"), value: PROJECT_STATES.PLANNED },
 ]);
 
 // MainMenu state filter (local – for MainMenu's internal state binding)
@@ -264,11 +265,11 @@ const countryList = computed(() =>
 
 const projectCount = computed(() => projectList.value.length);
 const projectsPlannedCount = computed(
-  () => projectStore.projects.filter((p) => p.state === "planned").length,
+  () => projectStore.projects.filter((p) => p.state === PROJECT_STATES.PLANNED).length,
 );
 const projectsUnderConstructionCount = computed(
   () =>
-    projectStore.projects.filter((p) => p.state === "under construction")
+    projectStore.projects.filter((p) => p.state === PROJECT_STATES.UNDER_CONSTRUCTION)
       .length,
 );
 
@@ -278,7 +279,7 @@ onBeforeMount(() => {
 
   // Set default state filters if none are active
   if (filterStore.stateFilter.length === 0) {
-    filterStore.stateFilter = ["finished", "planned", "under construction"];
+    filterStore.stateFilter = [PROJECT_STATES.FINISHED, PROJECT_STATES.PLANNED, PROJECT_STATES.UNDER_CONSTRUCTION];
   }
 });
 </script>


### PR DESCRIPTION
## Clean Code: Avoid Magic Strings

### Problem
Die Status-Werte `"finished"`, `"planned"`, `"under construction"` waren als rohe Strings über 19+ Fundstellen in 9 Dateien verteilt.

### Lösung
- `src/constants/projectStates.ts`: neues Konstanten-Objekt `PROJECT_STATES` + `normaliseProjectState()` Helper
- Migration aller Magic Strings zu `PROJECT_STATES.*`

### Geänderte Dateien (11)
| Datei | Änderung |
|-------|----------|
| `src/constants/projectStates.ts` | ✨ Neu: PROJECT_STATES + normaliseProjectState |
| `src/features/projects/services/project.service.ts` | resolveProjectState → normaliseProjectState |
| `src/features/projects/stores/project.store.ts` | PROJECT_STATES.* in allen Getters |
| `src/composables/useProjectSearch.ts` | Import + Referenz |
| `src/views/HomeView.vue` | stateOptions mit PROJECT_STATES.* |
| `src/views/ProjectListView.vue` | stateOptions + Filter mit PROJECT_STATES.* |
| `src/components/MainMenu.vue` | stateOptions mit PROJECT_STATES.* |
| `src/components/StateBadge.vue` | stateKeyMap mit PROJECT_STATES.* |
| `src/components/map/LocationMap.vue` | Filter + Template mit PROJECT_STATES.* |
| `src/components/project/ProjectListItem.vue` | stateLabels mit PROJECT_STATES.* |
| `src/utils/locale.ts` | ✨ Neu: shared locale utility (Dependency) |

### Auswirkungen
✅ −63 Zeilen Magic Strings
✅ Typsichere Umbenennungen durch TypeScript
✅ `normaliseProjectState()` normalisiert NocoDB-Varianten (under_construction, construction)